### PR TITLE
Adds 'Terms Used' section 

### DIFF
--- a/hardware-api.md
+++ b/hardware-api.md
@@ -128,6 +128,14 @@ i2c.transfer(new Buffer([0xde, 0xad, 0xbe, 0xef]), function (err, rx) {
 })
 ```
 
+### Terms Used
+
+The following sections use industry standard technical terms that are considered non-inclusive. They are used here in an explicitly technical manner and only to be accurate in describing these wire communication protocols. The terms are used strictly as defined here:
+
+**Master:** A machine or device directly controlling another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/master#master__7))
+
+**Slave:** A device, or part of one, directly controlled by another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/slave#slave__7))
+
 ### SPI
 
 A SPI channel uses the SCK, MISO, and MOSI pins (2, 3, and 4 on Tessel 2). If you are unfamiliar with the SPI protocol, please see the [communication protocols tutorial](https://tessel.io/docs/communicationProtocols#spi).


### PR DESCRIPTION
Fixes #63 

Acknowledges that `master`/`slave` are not terms chosen by the Tessel project, instead they are used as references to the hardware industry standard. 