### PR TITLE
Fix broken circuit link.

### DIFF
--- a/hardware-api.md
+++ b/hardware-api.md
@@ -105,7 +105,7 @@ Take a look at the following circuit. While the switch is open, pin2 will be
 low. When the button is pressed we'll complete the circuit and the voltage at
 pin2 will rise to 3.3V.
 
-![Interrupt Circuit](images/interrupt-circuit.png)
+![Interrupt Circuit](https://raw.githubusercontent.com/tessel/t2-docs/master/images/interrupt-circuit.png)
 
 Let's turn on the green LED when the button is pressed. Here's one way of doing
 it.


### PR DESCRIPTION
Addressing #70 

#69 had a bad link. This fixes it by using the `rawgithubcontent` link. Let me know if this is the best way to handle this or if I should be hosting the image elsewhere.

@HipsterBrown 