### PR TITLE
Tricks gitbook summary into listing Introduction first

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,4 +16,3 @@
   * [Interrupts](Tutorials/Interrupts.md)
   * [Making Your Own Module](Tutorials/Making_Your_Own_Module.md)
   * [Pulse Width Modulation](Tutorials/Pulse_Width_Modulation.md)
-* [Introduction](Introduction.md)

--- a/book.json
+++ b/book.json
@@ -5,7 +5,7 @@
         "readme": "Introduction.md"
       },
     "catalog": "all",
-    "ignores": ["_book", "node_modules", "GLOSSARY"],
+    "ignores": ["_book", "node_modules", "Introduction", "GLOSSARY"],
     "unchanged": [],
     "plugins" : [ "anchors" ]
 }


### PR DESCRIPTION
...by not listing it.

Master currently has the issue that in the sidebar, Introduction comes LAST. But if it's removed from the SUMMARY.md (by making it ignored), then it comes up first in the generated docs. Acceptable!