### PR TITLE
add non-breaking space to last cell in pin-mapping table - closes #113

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -56,7 +56,7 @@ The pin capabilities for ports A and B are as follows:
 | B | 4 | ✓ |   |   |   |   | ✓ |   |   | ✓ |   |   |   |
 | B | 5 | ✓ |   |   |   |   |   | ✓ |   | ✓ |   | ✓ | ✓ |
 | B | 6 | ✓ |   |   |   |   |   |   | ✓ | ✓ |   | ✓ | ✓ |
-| B | 7 | ✓ |   |   |   |   |   |   |   | ✓ | ✓ | ✓ |   |
+| B | 7 | ✓ |   |   |   |   |   |   |   | ✓ | ✓ | ✓ |&nbsp;|
 
 
 


### PR DESCRIPTION
The Pin Mapping table in the hardware-cli was missing the last cell because it's empty.  This is a bug in the markdown processor.  As a workaround, for now, added a non-breaking space so that the parser will see _something_ in that cell