### PR TITLE
add t2 key command to Tessel Management under CLI - Closes #12

### DIFF
--- a/API/CLI.md
+++ b/API/CLI.md
@@ -49,6 +49,7 @@ Along with the package.json and index.js included in the `t2 init` process, ther
 * `t2 list` will show what Tessels are available over WiFi and USB.
 * `t2 rename` will change the name of a Tessel.
 * `t2 reboot` will reboot your Tessel.  
+* `t2 key` will generate a local SSH keypair for authenticating to a Tessel.  Use with the `generate` argument.
 
 ### Code Deployment  
 During code deployment, CLI looks for `.tesselignore` and `.tesselinclude` files to let it know which files it should bundle up and push over to Tessel. In the default bundling process, CLI takes the file passed into the `run` or `push` command and uses it as an entry point to build a dependency graph (similar to [Browserify](https://github.com/substack/browserify-handbook#how-browserify-works)). Once the dependencies are known, binary modules are replaced by pre-compiled (for mips) binaries, assets are copied, and everything is tarred before sent to the awaiting Tessel.

--- a/API/CLI.md
+++ b/API/CLI.md
@@ -35,6 +35,7 @@ Usage
 *  `t2 root`
     * `[--timeout]` Set timeout in seconds for scanning networked Tessels. The default is `5` seconds.
     *  `[--key]` SSH key for authorization with your Tessel.  Optional, only required if you have changed the keypath after your Tessel was provisioned.
+      * `[--generate]` generates a new SSH keypair for authenticating to a Tessel.
     *  `[--name]` The name of the Tessel where the command will be executed.
     *  `[--output]`  Enable or disable writing command output to stdout/stderr. Useful for CLI API consumers.  Set to `true` by default
     *  `[--loglevel]`  Set the loglevel.  It is set to `basic` by default.  Available options are `'trace', 'debug', 'basic', 'info', 'http', 'warn', 'error'`
@@ -60,7 +61,7 @@ Along with the package.json and index.js included in the `t2 init` process, ther
 * `t2 list` will show what Tessels are available over WiFi and USB.
 * `t2 rename` will change the name of a Tessel.
 * `t2 reboot` will reboot your Tessel.  
-* `t2 key` will generate a local SSH keypair for authenticating to a Tessel.  Use with the `generate` argument.
+* `t2 key` will generate a local SSH keypair for authenticating to a Tessel.  Use with the `generate` argument to generate a new local SSH keypair for authenticating to a Tessel.
 
 ### Code Deployment  
 During code deployment, CLI looks for `.tesselignore` and `.tesselinclude` files to let it know which files it should bundle up and push over to Tessel. In the default bundling process, CLI takes the file passed into the `run` or `push` command and uses it as an entry point to build a dependency graph (similar to [Browserify](https://github.com/substack/browserify-handbook#how-browserify-works)). Once the dependencies are known, binary modules are replaced by pre-compiled (for mips) binaries, assets are copied, and everything is tarred before sent to the awaiting Tessel.

--- a/API/CLI.md
+++ b/API/CLI.md
@@ -35,7 +35,6 @@ Usage
 *  `t2 root`
     * `[--timeout]` Set timeout in seconds for scanning networked Tessels. The default is `5` seconds.
     *  `[--key]` SSH key for authorization with your Tessel.  Optional, only required if you have changed the keypath after your Tessel was provisioned.
-      * `[--generate]` generates a new SSH keypair for authenticating to a Tessel.
     *  `[--name]` The name of the Tessel where the command will be executed.
     *  `[--output]`  Enable or disable writing command output to stdout/stderr. Useful for CLI API consumers.  Set to `true` by default
     *  `[--loglevel]`  Set the loglevel.  It is set to `basic` by default.  Available options are `'trace', 'debug', 'basic', 'info', 'http', 'warn', 'error'`


### PR DESCRIPTION
Took a shot at documenting the `t2 key` command.  
