### PR TITLE
Expand Tessel power management docs

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -292,15 +292,20 @@ uart.pipe(process.stdout);
 ```
 
 ### Power management
-Tessel 2's firmware turns off power to the port if a program does not require the `tessel` module. However, if `tessel` is required in the code, both will be turned on by default. It is possible to turn off the other module port with an explicit call:
 
-```js
-var tessel = require('tessel');
+#### Board
 
-tessel.close('A'); // A is now closed
+**tessel.reboot:**
+
+Power cycle the board. This will clear RAM and restart the program once reboot is complete.
+
+```
+tessel.reboot();
 ```
 
-In cases requiring more manual control, it is possible to specify the behaviors of both module ports as follows:
+#### Ports
+
+Tessel 2's firmware turns off power to the port if a program does not require the `tessel` module. However, if `tessel` is required in the code, both will be turned on by default. It is possible to control the power to module ports with an explicit call:
 
 ```js
 var Tessel = require('tessel-export');
@@ -311,10 +316,35 @@ var tessel = new Tessel({
    B: false,
  }
 });
-
-tessel.open('A'); // A is now open
-tessel.open('B'); // B is now open
 ```
+
+**tessel.open:**
+
+Open power to one or both Tessel ports.
+
+```js
+tessel.open(portName);
+```
+
+option   | type   | description       | required
+---------|--------|-------------------|---------
+portName | String | either 'A' or 'B' | no
+
+Leaving out the port name will turn on power to both ports.
+
+**tessel.close:**
+
+Close power to one or both Tessel ports.
+
+```js
+tessel.close(portName);
+```
+
+option   | type   | description       | required
+---------|--------|-------------------|---------
+portName | String | either 'A' or 'B' | no
+
+Leaving out the port name will turn off power to both ports.
 
 ## Button and LEDs
 There are 4 LEDs available on the Tessel 2, you may see them labeled on the board as `ERR`, `WLAN`, `LED0`, and `LED1`. They are available through the `tessel.led` object.

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -297,7 +297,7 @@ uart.pipe(process.stdout);
 
 **tessel.reboot:**
 
-Power cycle the board. This will clear RAM and restart the program once reboot is complete.
+Power cycle the board. This will clear RAM and restart the program once reboot is complete. This can be done with the [`t2 reboot`](/API/CLI.html#tessel-management) command as well.
 
 ```
 tessel.reboot();
@@ -320,7 +320,7 @@ var tessel = new Tessel({
 
 **tessel.open:**
 
-Open power to one or both Tessel ports.
+Allow power to one or both Tessel ports.
 
 ```js
 tessel.open(portName);
@@ -330,11 +330,11 @@ option   | type   | description       | required
 ---------|--------|-------------------|---------
 portName | String | either 'A' or 'B' | no
 
-Leaving out the port name will turn on power to both ports.
+Leaving out the port name will turn on power to both ports, i.e. `tessel.open()`.
 
 **tessel.close:**
 
-Close power to one or both Tessel ports.
+Disallow power to one or both Tessel ports.
 
 ```js
 tessel.close(portName);
@@ -344,7 +344,7 @@ option   | type   | description       | required
 ---------|--------|-------------------|---------
 portName | String | either 'A' or 'B' | no
 
-Leaving out the port name will turn off power to both ports.
+Leaving out the port name will turn off power to both ports, i.e. `tessel.close()`.
 
 ## Button and LEDs
 There are 4 LEDs available on the Tessel 2, you may see them labeled on the board as `ERR`, `WLAN`, `LED0`, and `LED1`. They are available through the `tessel.led` object.


### PR DESCRIPTION
This PR organizes the "Power Management" section of the Hardware API page to match the style set by the "Interrupt pins" and "PWM pins" sections. It also adds documentation for the `tessel.reboot` method. 