### PR TITLE
Define official digital pin methods

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -66,18 +66,58 @@ By default, all of the pins are pulled high if not specifically set.
 
 ### Digital pins
 
-A digital pin (any pin other than 3.3V and GND on Tessel 2) is either high (on/3.3V) or low (off/0V). On both of ports A and B, pins 0 and 1 are pulled high to 3.3V by default.
+A digital pin (any pin other than 3.3V and GND on Tessel 2) is either high (on/3.3V) or low (off/0V). On both of ports A and B, all pins are pulled high to 3.3V by default.
 
-Here is an example usage of a digital pin on Tessel:
+**pin.write:**
+
+Set the digital value of a pin.
+
+```js
+pin.write(number, callback(error, buffer));
+```
+
+option    | type     | description                   | required
+----------|----------|-------------------------------|---------
+number    | Number   | 0 for "low", 1 for "high"     | yes
+callback  | Function | Called when write is complete | yes
+
+Example:
 
 ```js
 var tessel = require('tessel'); // import tessel
 var pin = tessel.port.A.pin[2]; // select pin 2 on port A
-pin.output(1);  // turn pin high (on)
-pin.read(function(error, value) {
-  // print the pin value to the console
-  console.log(value);
-  pin.output(0);  // turn pin low (off)
+pin.write(1, (error, buffer) => {
+  if (error) {
+    throw error;
+  }
+
+  console.log(buffer.toString()); // log the value
+});
+```
+
+**pin.read:**
+
+Read the digital value of a pin.
+
+```js
+pin.read(callback(error, number));
+```
+
+option    | type     | description                  | required
+----------|----------|------------------------------|---------
+callback  | Function | Called when read is complete | yes
+
+Example:
+
+```js
+var tessel = require('tessel'); // import tessel
+var pin = tessel.port.A.pin[2]; // select pin 2 on port A
+pin.read(function(error, number) {
+  if (error) {
+    throw error;
+  }
+
+  console.log(number); // 1 if "high", 0 if "low"
 });
 ```
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -76,12 +76,12 @@ Set the digital value of a pin.
 pin.write(number, callback(error, buffer));
 ```
 
-Option    | Type     | Description                   | Required
-----------|----------|-------------------------------|---------
-number    | Number   | 0 for "low", 1 for "high"     | yes
-callback  | Function | Called when write is complete | yes
-
-`buffer` is an instance of the [Buffer class](https://nodejs.org/docs/latest-v4.x/api/buffer.html).
+Option    | Type     | Description                                                                                                     | Required
+----------|----------|-----------------------------------------------------------------------------------------------------------------|---------
+number    | Number                                                        | 0 for "low", 1 for "high"                                  | yes
+callback  | Function                                                      | Called when write is complete                              | yes
+error     | Error                                                         | Contains information if an error occured, otherwise `null` | yes
+buffer    | [Buffer](https://nodejs.org/docs/latest-v4.x/api/buffer.html) | Value written to the pin | yes
 
 Example:
 
@@ -105,9 +105,11 @@ Read the digital value of a pin.
 pin.read(callback(error, number));
 ```
 
-Option    | Type     | Description                  | Required
-----------|----------|------------------------------|---------
-callback  | Function | Called when read is complete | yes
+Option    | Type     | Description                                                | Required
+----------|----------|------------------------------------------------------------|---------
+callback  | Function | Called when read is complete                               | yes
+error     | Error    | Contains information if an error occured, otherwise `null` | yes
+number    | Number   | 1 if "high", 0 if "low"                                    | yes
 
 Example:
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -66,7 +66,7 @@ By default, all of the pins are pulled high if not specifically set.
 
 ### Digital pins
 
-A digital pin (any pin other than 3.3V and GND on Tessel 2) is either high (on/3.3V) or low (off/0V). On both of ports A and B, all pins are pulled high to 3.3V by default.
+A digital pin is either high (on/3.3V) or low (off/0V). Any pin on both ports A and B, other than 3.3V and GND, can be used be used as a digital pin. All pins are pulled high to 3.3V by default.
 
 **pin.write:**
 
@@ -76,22 +76,24 @@ Set the digital value of a pin.
 pin.write(number, callback(error, buffer));
 ```
 
-option    | type     | description                   | required
+Option    | Type     | Description                   | Required
 ----------|----------|-------------------------------|---------
 number    | Number   | 0 for "low", 1 for "high"     | yes
 callback  | Function | Called when write is complete | yes
 
+`buffer` is an instance of the [Buffer class](https://nodejs.org/docs/latest-v4.x/api/buffer.html).
+
 Example:
 
 ```js
-var tessel = require('tessel'); // import tessel
-var pin = tessel.port.A.pin[2]; // select pin 2 on port A
+var tessel = require('tessel'); // Import tessel
+var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
 pin.write(1, (error, buffer) => {
   if (error) {
     throw error;
   }
 
-  console.log(buffer.toString()); // log the value
+  console.log(buffer.toString()); // Log the value written to the pin
 });
 ```
 
@@ -103,15 +105,15 @@ Read the digital value of a pin.
 pin.read(callback(error, number));
 ```
 
-option    | type     | description                  | required
+Option    | Type     | Description                  | Required
 ----------|----------|------------------------------|---------
 callback  | Function | Called when read is complete | yes
 
 Example:
 
 ```js
-var tessel = require('tessel'); // import tessel
-var pin = tessel.port.A.pin[2]; // select pin 2 on port A
+var tessel = require('tessel'); // Import tessel
+var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
 pin.read(function(error, number) {
   if (error) {
     throw error;


### PR DESCRIPTION
This PR organizes the "Digital pins" section of the Hardware API page to match the style set by the "Interrupt pins" and "PWM pins" sections.

Preview:

<img width="865" alt="screen shot 2017-01-19 at 4 08 51 pm" src="https://cloud.githubusercontent.com/assets/3051193/22125653/88a82ed6-de62-11e6-9dac-3c799cb3d338.png">

<img width="819" alt="screen shot 2017-01-19 at 4 09 01 pm" src="https://cloud.githubusercontent.com/assets/3051193/22125662/913ea7b4-de62-11e6-9610-8f779f9cd97d.png">