### PR TITLE
Define official analog pin methods

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -139,7 +139,7 @@ pin.analogWrite(number);
 
 Option | Type   | Description                      | Required
 -------|--------|----------------------------------|---------
-number | Number | minimum value 0, maximum value 1 | yes
+number | Number | Minimum value 0, maximum value 1 | yes
 
 Example:
 
@@ -161,7 +161,7 @@ Option   | Type     | Description                                               
 ---------|----------|------------------------------------------------------------|---------
 callback | Function | Called when read is complete                               | yes
 error    | Error    | Contains information if an error occured, otherwise `null` | yes
-number   | Number   | minimum value 0, maximum value 1                           | yes
+number   | Number   | Minimum value 0, maximum value 1                           | yes
 
 Example:
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -127,17 +127,51 @@ pin.read(function(error, number) {
 
 ### Analog pins
 
-An analog pin is a pin whose value can vary in the range between 0V and 3.3V. Pins 4 and 7 on port A and all pins on port B can read analog values (though pins 0 and 1 are pulled to 3.3V by default and are thus not recommended for this purpose). Pin 7 on port B can write an analog value.
+An analog pin is a pin whose value can vary in the range between 0V and 3.3V. 
 
-Here is an example usage of an analog pin on Tessel:
+**pin.analogWrite:**
+
+Set the analog value of a pin. Enabled on Port B, pin 7.
+
+```js
+pin.analogWrite(number);
+```
+
+option | type   | description                      | required
+-------|--------|----------------------------------|---------
+number | Number | minimum value 0, maximum value 1 | yes
+
+Example:
 
 ```js
 var tessel = require('tessel'); // import tessel
 var pin = tessel.port.B.pin[7]; // select pin 7 on port B
-pin.analogWrite(0.6);  // turn pin to 60% of high
-pin.analogRead(function(error, value) {
-  // print the pin value to the console
-  console.log(value);
+pin.analogWrite(0.6);  // turn pin to 60% of high voltage
+```
+
+**pin.analogRead:**
+
+Read the analog value of a pin. Enabled on Port A, pin 4 and 7, Port B, all pins. On both ports, all pins are pulled high be default.
+
+```js
+pin.analogRead(callback(error, number));
+```
+
+option   | type     | description                  | required
+---------|----------|------------------------------|---------
+callback | Function | Called when read is complete | yes
+
+Example:
+
+```js
+var tessel = require('tessel'); // import tessel
+var pin = tessel.port.A.pin[4]; // select pin 4 on port A
+pin.analogRead((error, number) => {
+  if (error) {
+    throw error;
+  }
+
+  console.log(number); // the number is a value between 0 and 1
 });
 ```
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -127,51 +127,51 @@ pin.read(function(error, number) {
 
 ### Analog pins
 
-An analog pin is a pin whose value can vary in the range between 0V and 3.3V. 
+An analog pin is a pin whose value can vary in the range between 0V and 3.3V. The analog pin API represents these this value as a percentage, between 0 and 1, where 1 stands for 3.3V.
 
 **pin.analogWrite:**
 
-Set the analog value of a pin. Enabled on Port B, pin 7.
+Set the analog value of a pin. Enabled on pin 7 of Port B.
 
 ```js
 pin.analogWrite(number);
 ```
 
-option | type   | description                      | required
+Option | Type   | Description                      | Required
 -------|--------|----------------------------------|---------
 number | Number | minimum value 0, maximum value 1 | yes
 
 Example:
 
 ```js
-var tessel = require('tessel'); // import tessel
-var pin = tessel.port.B.pin[7]; // select pin 7 on port B
-pin.analogWrite(0.6);  // turn pin to 60% of high voltage
+var tessel = require('tessel'); // Import tessel
+var pin = tessel.port.B.pin[7]; // Select pin 7 on port B
+pin.analogWrite(0.6);  // Turn pin to 60% of high voltage
 ```
 
 **pin.analogRead:**
 
-Read the analog value of a pin. Enabled on Port A, pin 4 and 7, Port B, all pins. On both ports, all pins are pulled high be default.
+Read the analog value of a pin. Enabled on pins 4 and 7 on Port A,and all pins on Port B. On both ports, all pins are pulled high by default, which means a pin not connected to any sort of sensor or resistor can still return a value over 0.
 
 ```js
 pin.analogRead(callback(error, number));
 ```
 
-option   | type     | description                  | required
+Option   | Type     | Description                  | Required
 ---------|----------|------------------------------|---------
 callback | Function | Called when read is complete | yes
 
 Example:
 
 ```js
-var tessel = require('tessel'); // import tessel
-var pin = tessel.port.A.pin[4]; // select pin 4 on port A
+var tessel = require('tessel'); // Import tessel
+var pin = tessel.port.A.pin[4]; // Select pin 4 on port A
 pin.analogRead((error, number) => {
   if (error) {
     throw error;
   }
 
-  console.log(number); // the number is a value between 0 and 1
+  console.log(number); // The number is a value between 0 and 1
 });
 ```
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -157,9 +157,11 @@ Read the analog value of a pin. Enabled on pins 4 and 7 on Port A,and all pins o
 pin.analogRead(callback(error, number));
 ```
 
-Option   | Type     | Description                  | Required
----------|----------|------------------------------|---------
-callback | Function | Called when read is complete | yes
+Option   | Type     | Description                                                | Required
+---------|----------|------------------------------------------------------------|---------
+callback | Function | Called when read is complete                               | yes
+error    | Error    | Contains information if an error occured, otherwise `null` | yes
+number   | Number   | minimum value 0, maximum value 1                           | yes
 
 Example:
 


### PR DESCRIPTION
This PR organizes the "Analog pins" section of the Hardware API page to match the style set by the "Interrupt pins" and "PWM pins" sections.

Preview:

<img width="834" alt="screen shot 2017-01-19 at 5 17 43 pm" src="https://cloud.githubusercontent.com/assets/3051193/22127745/501a1ec2-de6b-11e6-8f56-12b9f2376926.png">

<img width="830" alt="screen shot 2017-01-19 at 5 17 53 pm" src="https://cloud.githubusercontent.com/assets/3051193/22127750/5476c2fe-de6b-11e6-9a1e-34ac353ea75b.png">