### PR TITLE
Reorders TOC in Hardware API

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -7,8 +7,9 @@
   * [Analog pins](#analog-pins)
   * [Interrupts](#interrupt-pins)
   * [PWM pins](#pwm-pins)
-  * [SPI](#spi)
+  * [Terms used](#terms-used)
   * [I2C](#i2c)
+  * [SPI](#spi)
   * [UART/Serial](#uart-serial)
   * [Power management](#power-management)
 * [Button and LEDs](#button-and-leds)
@@ -242,6 +243,14 @@ number | Number | minimum value 0, maximum value 1, e.g. 0.6 | yes
 
 [Learn more about using the PWM API.](/Tutorials/Pulse_Width_Modulation.html)
 
+### Terms Used
+
+The following sections use industry standard technical terms that are considered non-inclusive. They are used here in an explicitly technical manner and only to be accurate in describing these wire communication protocols. The terms are used strictly as defined here:
+
+**Master:** A machine or device directly controlling another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/master#master__7))
+
+**Slave:** A device, or part of one, directly controlled by another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/slave#slave__7))
+
 ### I2C
 
 An I2C channel uses the SCL and SDA pins (0 and 1 on Tessel 2). If you are unfamiliar with the I2C protocol, please see the [communication protocols tutorial](https://tessel.io/docs/communicationProtocols#i2c).
@@ -318,14 +327,6 @@ i2c.read(numBytesToRead, function (error, dataReceived) {
   console.log('Buffer returned by I2C slave device ('+slaveAddress.toString(16)+'):', dataReceived);
 });
 ```
-
-### Terms Used
-
-The following sections use industry standard technical terms that are considered non-inclusive. They are used here in an explicitly technical manner and only to be accurate in describing these wire communication protocols. The terms are used strictly as defined here:
-
-**Master:** A machine or device directly controlling another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/master#master__7))
-
-**Slave:** A device, or part of one, directly controlled by another (source: [Oxford Dictionary](http://www.oxforddictionaries.com/us/definition/american_english/slave#slave__7))
 
 ### SPI
 

--- a/Hardware/Tessel_2_Overview.md
+++ b/Hardware/Tessel_2_Overview.md
@@ -26,11 +26,11 @@ Above-and-beyond features:
 
 On the board, Tessel 2 is divided into three functional blocks:
 
-![](http://67.media.tumblr.com/83018b7f2595c1f4b3877f74eb86d134/tumblr_inline_nkz56hKzbm1s75tgz.png)
+![](http://i.imgur.com/5RturZe.png)
 
 These can be abstracted as follows:
 
-![](http://65.media.tumblr.com/559c4d45074644a5c335987bec7c698e/tumblr_inline_nkz56bL5SC1s75tgz.png)
+![](http://i.imgur.com/LU9UNf1.png)
 
 ### Abstraction boundaries of Tessel 2
 


### PR DESCRIPTION
fixes https://github.com/tessel/t2-docs/issues/79

Previously, the sections were listed in the TOC at the top in a different order than the sections appeared. This has been corrected, and "Terms Used" has been moved above all of the communication protocols per @rwaldron's suggestion