### PR TITLE
Adds Rust quickstart info to the docs

### DIFF
--- a/API/Supported_Languages.md
+++ b/API/Supported_Languages.md
@@ -1,12 +1,17 @@
 # Supported languages
 
+* [Javascript/Node.js](#javascriptnodejs)
+  * [Binary Modules](#binary-modules)
+* [Rust](#rust)
+* [Other Languages](#other-languages)
+
 ## JavaScript/Node.js
 Tessel 2 has full support for JavaScript and Node.js (LTS versions). The relevant repos can be found here:
 
 * [Firmware support for JavaScript/Node](https://github.com/tessel/t2-firmware)
 * [CLI support for JavaScript/Node](https://github.com/tessel/t2-cli/blob/master/lib/tessel/deployment/javascript.js)
 
-### Binary modules
+### Binary Modules
 
 There is support for binary modules on Tessel 2 that are precompiled. The best way to find out whether the module you want is available is to try deploying it. The module has been precompiled, it will just work!
 
@@ -26,9 +31,44 @@ Please file an issue at https://github.com/tessel/t2-cli/issues/new
 Submit an issue and we will look into precompiling it. Our precompilation server lives in the [`t2-compiler` repo](http://github.com/tessel/t2-compiler).
 
 ## Rust (work in progress)
-The Tessel team is working toward first-class support for Rust. If you're interested in the state of that project, check out the [tessel-rust repo](https://github.com/tessel/rust-tessel).
+Try Rust on Tessel 2 with the following instructions:
 
-## How to add support for more languages
+Install Tessel 2's command line tool (the same CLI as is used for JavaScript/Node.js) with
+
+```
+npm install -g t2-cli
+```
+
+You can then create an deploy a blinking lights example using the CLI. Make a folder to work in:
+
+```
+mkdir quickstart
+cd quickstart
+```
+
+In your new folder, automatically initialize all the files you need to run your first Rust code on Tessel 2 with:
+
+```
+t2 init --lang=rust
+```
+
+You will see a file called `Cargo.toml`, and a folder called `src` containing `main.rs`. `main.rs` is a script to blink some of Tessel's built-in LEDs.
+
+Run the code with
+
+```
+t2 run blinky --rustcc
+```
+
+The `--rustcc` compiles the Rust script for your Tessel on a remote server.
+
+You use the name `blinky` when you are running your code because that is the name specified in `Cargo.toml`.
+
+The lights on your Tessel 2 should be blinking!
+
+Want to go further? Check out the [tessel-rust repo](https://github.com/tessel/rust-tessel) to see how to do local compilation, use modules, and more.
+
+## Other Languages
 Interested in adding support for a new language to Tessel 2's CLI? Here is a detailed blog post on the six components you will need: [Interfacing with the Language Plugin API for Tessel 2](https://tessel.io/blog/148706216397/interfacing-with-the-language-plugin-api-for)
 
 (It is worth noting that [support of Python for Tessel 2](https://github.com/tcr/tessel-python) was originally planned, but is no longer in active development. [Read the blog post](https://tessel.io/blog/146714850172/ramping-up-rust-backing-away-from-python-johnny) explaining this decision.)


### PR DESCRIPTION
Good place to start? If we're going to do more thorough documentation, I think we'll have to figure out our full-scale Rust Docs solution a la https://github.com/tessel/t2-start/issues/5#issuecomment-244568098