### PR TITLE
fixes #93 

### DIFF
--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -68,9 +68,9 @@ If you're newer to hardware and these functions look like alphabet soup to you, 
 
 By default, all of the pins are pulled high if not specifically set.
 
-### Pullup and Pulldown pins
+### Pull-up and Pull-down pins
 
-Pins 2-7 on both Ports are available for pullup and pulldown.
+Pins 2-7 on both Ports are available for pull-up and pull-down.
 
 The basic function of a pull-up resistor is to ensure that given no other input, a circuit assumes a default value. The 'pullup' mode pulls the line high and the 'pulldown' mode pulls it low.
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -72,7 +72,7 @@ By default, all of the pins are pulled high if not specifically set.
 
 Pins 2-7 on both Ports are available for pullup and pulldown.
 
-The basic function of a pull-up resistor is to insure that given no other input, a circuit assumes a default value. The 'pullup' mode pulls the line high and the 'pulldown' mode pulls it low.
+The basic function of a pull-up resistor is to ensure that given no other input, a circuit assumes a default value. The 'pullup' mode pulls the line high and the 'pulldown' mode pulls it low.
 
 ### Usage
 ```js
@@ -80,46 +80,23 @@ The basic function of a pull-up resistor is to insure that given no other input,
 pin.pull(pullType, callback);
 ```
 
-Example of the `pin.pull(mode)` command using a pushbutton. The code example given below turns on the Blue LED of the Tessel module when the pushbutton is pressed and turns off the Blue LED when the pushbutton is released.
+Example : 
+
 
 ```js
 var tessel= require('tessel'); // Import Tessel
 
 var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
 
-var pullType = "pullup"; // Set the mode of `pin.pull to pullup`
-
-var led = tessel.led[3]; // Blue LED of Tessel
-
-pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
-
-  if (error){
+pin.pull('pullup', (error, buffer) => { // Pin 2 pulled high
+  if (error) {
     throw error;
   }
-});
-
-setInterval({
-  pin.read(function(error, number){
-
-      if (error) {
-        throw error;
-      }
-
-      // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
-      console.log(number);
-      if (number == 1){
-        led.off();
-      }
-
-      // Pin 2 reads low when the pushbutton is pressed since its connection with ground gets complete
-      else{
-        led.on();
-      }
-
-  });
-
-}, 500);
+  console.log(buffer.toString()) // what should this be?
+}
 ```
+
+[Learn more about using the Pullup / Pulldown API.](/Tutorials/pinpull.html)
 
 
 

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -88,12 +88,13 @@ var tessel= require('tessel'); // Import Tessel
 
 var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
 
-pin.pull('pullup', (error, buffer) => { // Pin 2 pulled high
-  if (error) {
-    throw error;
-  }
-  console.log(buffer.toString()) // what should this be?
-}
+pin.pull('pullup', (error, buffer) => {
+    if (error) {
+        throw error;
+    }
+    
+    console.log(buffer.toString('hex')); // The output would be 88. Which is an OK Signal from SAMD21
+})
 ```
 
 [Learn more about using the Pullup / Pulldown API.](/Tutorials/pinpull.html)

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -68,6 +68,61 @@ If you're newer to hardware and these functions look like alphabet soup to you, 
 
 By default, all of the pins are pulled high if not specifically set.
 
+### Pullup and Pulldown pins
+
+Pins 2-7 on both Ports are available for pullup and pulldown.
+
+The basic function of a pull-up resistor is to insure that given no other input, a circuit assumes a default value. The 'pullup' mode pulls the line high and the 'pulldown' mode pulls it low.
+
+### Usage
+```js
+// Invoke this method to set the pull mode. pullType can be - pullup, pulldown or none.
+pin.pull(pullType, callback);
+```
+
+Example of the `pin.pull(mode)` command using a pushbutton. The code example given below turns on the Blue LED of the Tessel module when the pushbutton is pressed and turns off the Blue LED when the pushbutton is released.
+
+```js
+var tessel= require('tessel'); // Import Tessel
+
+var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
+
+var pullType = "pullup"; // Set the mode of `pin.pull to pullup`
+
+var led = tessel.led[3]; // Blue LED of Tessel
+
+pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
+
+  if (error){
+    throw error;
+  }
+});
+
+setInterval({
+  pin.read(function(error, number){
+
+      if (error) {
+        throw error;
+      }
+
+      // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
+      console.log(number);
+      if (number == 1){
+        led.off();
+      }
+
+      // Pin 2 reads low when the pushbutton is pressed since its connection with ground gets complete
+      else{
+        led.on();
+      }
+
+  });
+
+}, 500);
+```
+
+
+
 ### Digital pins
 
 A digital pin is either high (on/3.3V) or low (off/0V). Any pin on both ports A and B, other than 3.3V and GND, can be used be used as a digital pin. All pins are pulled high to 3.3V by default.

--- a/API/Hardware_API.md
+++ b/API/Hardware_API.md
@@ -3,6 +3,7 @@
 * [Ports and pins](#ports-and-pins)
   * [Modules](#modules)
   * [Pin mapping](#pin-mapping)
+  * [Pull-up and Pull-down pins](#pull-up-and-pull-down-pins)
   * [Digital pins](#digital-pins)
   * [Analog pins](#analog-pins)
   * [Interrupts](#interrupt-pins)

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -58,6 +58,12 @@ Points of electrical connection with an integrated circuit
 ## ports
 Interfaces for electrical connections
 
+## pull-up
+Ensures that given no input, the circuit assumes a defualt value, which is pulled high.
+
+## pull-down 
+Ensures that given no input, the circuit assumes a default value, which is pulled low.
+
 ## PWM
 Pulse-width modulation: a hardware communication protocol where there is a digital signal fluctuating between values at a set period, and the message is encoded by changing the percentage of that period in which the signal stays at one of the values. This can be used to approximate an analog signal on a pin which only supports digital signaling. A common application is in motor controllers, mapping a servo motor position to the percentage of the time a signal is held high
 

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -22,28 +22,30 @@ pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
   if (error){
     throw error;
   }
+  
+  setInterval(() => {
+    pin.read(function(error, number){
+
+        if (error) {
+          throw error;
+        }
+
+        // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
+        console.log(number);
+        if (number == 1){
+          led.off();
+        }
+
+        // Pin 2 reads low when the pushbutton is pressed since its connection with ground is completed
+        else{
+          led.on();
+        }
+
+    });
+
+  }, 500);
+  
 });
 
-setInterval(() => {
-  pin.read(function(error, number){
-
-      if (error) {
-        throw error;
-      }
-
-      // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
-      console.log(number);
-      if (number == 1){
-        led.off();
-      }
-
-      // Pin 2 reads low when the pushbutton is pressed since its connection with ground is completed
-      else{
-        led.on();
-      }
-
-  });
-
-}, 500);
 ```
 [More information on Pull-up pins and resistors (Sparkfun Tutorials)](https://learn.sparkfun.com/tutorials/pull-up-resistors)

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -6,14 +6,14 @@ Pins 2-7 on both the Ports are available for interrupts.
 
 Take a look at the following circuit. The code example given below turns on the Blue LED of the Tessel module when the pushbutton is pressed and turns off the Blue LED when the pushbutton is released.
 
-![Pin-Pull using Push buttons](http://i.imgur.com/OYJZ8Dp.jpg)
+![Pin-pull using Push buttons](http://i.imgur.com/OYJZ8Dp.jpg)
 
 ```js
 var tessel= require('tessel'); // Import Tessel
 
 var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
 
-var pullType = "pullup"; // Set the mode of `pin.pull to pullup`
+var pullType = "pullup"; // Set the mode of `pin.pull` to pullup
 
 var led = tessel.led[3]; // Blue LED of Tessel
 
@@ -37,7 +37,7 @@ setInterval(() => {
         led.off();
       }
 
-      // Pin 2 reads low when the pushbutton is pressed since its connection with ground gets complete
+      // Pin 2 reads low when the pushbutton is pressed since its connection with ground is completed
       else{
         led.on();
       }
@@ -46,4 +46,4 @@ setInterval(() => {
 
 }, 500);
 ```
-[More Information on Pull-up pins and resistors](https://learn.sparkfun.com/tutorials/pull-up-resistors)
+[More information on Pull-up pins and resistors (Sparkfun Tutorials)](https://learn.sparkfun.com/tutorials/pull-up-resistors)

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -24,15 +24,16 @@ pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
   }
   
   setInterval(() => {
-    pin.read(function(error, number){
+    pin.read(function(error, valReturned){
+        // valReturned is the digital value that is returned from the pin
 
         if (error) {
           throw error;
         }
 
         // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
-        console.log(number);
-        if (number == 1){
+        console.log(valReturned);
+        if (valReturned == 1){
           led.off();
         }
 

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -1,0 +1,49 @@
+# Pull- Pins
+
+Suppose a pin is configured as an input. If nothing is connected to the pin and the program tries to read the state of the pin, it would be in a 'floating' state i.e an unknown state. To prevent this, a pull-up or a pull-down state is defined. They are often used in the case of Buttons and Switches.
+
+Pins 2-7 on both the Ports are available for interrupts.
+
+Take a look at the following circuit. The code example given below turns on the Blue LED of the Tessel module when the pushbutton is pressed and turns off the Blue LED when the pushbutton is released.
+
+![Pin-Pull using Push buttons](http://i.imgur.com/OYJZ8Dp.jpg)
+
+```js
+var tessel= require('tessel'); // Import Tessel
+
+var pin = tessel.port.A.pin[2]; // Select pin 2 on port A
+
+var pullType = "pullup"; // Set the mode of `pin.pull to pullup`
+
+var led = tessel.led[3]; // Blue LED of Tessel
+
+pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
+
+  if (error){
+    throw error;
+  }
+});
+
+setInterval({
+  pin.read(function(error, number){
+
+      if (error) {
+        throw error;
+      }
+
+      // Pin 2 reads high when the pushbutton is not pressed since it is pulled up
+      console.log(number);
+      if (number == 1){
+        led.off();
+      }
+
+      // Pin 2 reads low when the pushbutton is pressed since its connection with ground gets complete
+      else{
+        led.on();
+      }
+
+  });
+
+}, 500);
+```
+[More Information on Pull-up pins and resistors](https://learn.sparkfun.com/tutorials/pull-up-resistors)

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -24,7 +24,7 @@ pin.pull(pullType,(error, buffer) => { // Pin 2 pulled high
   }
 });
 
-setInterval({
+setInterval(() => {
   pin.read(function(error, number){
 
       if (error) {

--- a/Tutorials/pinpull.md
+++ b/Tutorials/pinpull.md
@@ -2,7 +2,7 @@
 
 Suppose a pin is configured as an input. If nothing is connected to the pin and the program tries to read the state of the pin, it would be in a 'floating' state i.e an unknown state. To prevent this, a pull-up or a pull-down state is defined. They are often used in the case of Buttons and Switches.
 
-Pins 2-7 on both the Ports are available for interrupts.
+Pins 2-7 on both the Ports are available for pull-up and pull-down.
 
 Take a look at the following circuit. The code example given below turns on the Blue LED of the Tessel module when the pushbutton is pressed and turns off the Blue LED when the pushbutton is released.
 


### PR DESCRIPTION
This fixes #93 

@HipsterBrown - Could you please let us know where to add the Fritzing demo as stated in the issue?

Yet to add - the "Available pin modes" section as done in the documentation of [Interrupt Pins](https://tessel.gitbooks.io/t2-docs/content/API/Hardware_API.html#interrupt-pins) and the default setting of the pin if the mode is 'none'

